### PR TITLE
Add linting in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - '4'
+  - '6'
+  - '7'
+cache:
+    directories:
+        - node_modules
+    sudo: false
+    script: npm run test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "amen-js",
+  "version": "0.0.0",
+  "description": "JavaScript wrapper for Amen - a replacement for remix.js",
+  "main": "amen.js",
+  "scripts": {
+    "test": "eslint ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algorithmic-music-exploration/amen-js.git"
+  },
+  "author": "",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/algorithmic-music-exploration/amen-js/issues"
+  },
+  "homepage": "https://github.com/algorithmic-music-exploration/amen-js#readme",
+  "devDependencies": {
+    "eslint": "^3.19.0"
+  }
+}


### PR DESCRIPTION
Fixes #2

Pretty low hanging fruit, just saw the issue and thought I'd jump on it.

Worth noting:
1. eslint doesn't pass because `initializeAmen` is created but not used, triggering eslint's `no-undef`. This'll be fixed by exporting the function using `module.exports = initializeAmen;` rather than via a global variable
2. It assumes you like the choice of Travis CI as a CI solution. I'm happy to change this for Circle or whatever else you prefer, but Travis is my usual go to.
3. You will also have to turn on CI in your [travis ci dashboard](https://travis-ci.org/dashboard). Travis is free for open source 😄 